### PR TITLE
fix: correct htts typos to https in package.json URLs

### DIFF
--- a/create-dist-package.json.js
+++ b/create-dist-package.json.js
@@ -16,12 +16,12 @@ const content = {
   module: 'index.js',
   repository: {
     type: 'git',
-    url: 'git+htts://github.com/catull/calendariale.git'
+    url: 'git+https://github.com/catull/calendariale.git'
   },
   bugs: {
-    url: 'htts://github.com/catull/calendariale/issues'
+    url: 'https://github.com/catull/calendariale/issues'
   },
-  homepage: 'htts://github.com/catull/calendariale',
+  homepage: 'https://github.com/catull/calendariale',
   exports: {
     './package.json': './package.json',
     '.': {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+htts://github.com/catull/calendariale.git"
+    "url": "git+https://github.com/catull/calendariale.git"
   },
   "bugs": {
-    "url": "htts://github.com/catull/calendariale/issues"
+    "url": "https://github.com/catull/calendariale/issues"
   },
-  "homepage": "htts://github.com/catull/calendariale",
+  "homepage": "https://github.com/catull/calendariale",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixed a bug I found while browsing. The `repository.url`, `bugs.url`, and `homepage` fields in `package.json` (and the matching values in `create-dist-package.json.js`) all contained the typo `htts://` instead of `https://`. This breaks the repository/bugs/homepage links in the published package metadata on npm and elsewhere.

### Changes
- `package.json`: fixed 3 URL fields
- `create-dist-package.json.js`: fixed 3 matching URL fields so the dist package.json stays consistent

### Before
```
"url": "htts://github.com/catull/calendariale/issues"
```

### After
```
"url": "https://github.com/catull/calendariale/issues"
```

— Sent via @AmSach bot
