### PR TITLE
Fix Ethiopic leap year: year % 4 === 3 (closes #675)

### DIFF
--- a/src/calendar/EthiopicCalendar.ts
+++ b/src/calendar/EthiopicCalendar.ts
@@ -22,7 +22,7 @@ export class EthiopicCalendar {
   }
 
   public static isLeapYear(year: number): boolean {
-    return mod(year, 4) === 0;
+    return mod(year, 4) === 3;
   }
 
   private static validate(year: number, month: number, day: number): void {

--- a/test/calendar/Ethiopic.test.ts
+++ b/test/calendar/Ethiopic.test.ts
@@ -70,4 +70,39 @@ describe("ethiopic calendar spec", () => {
     expect(() => cal.toJdn(1000, 13, 7)).toThrow(INVALID_DAY);
     expect(() => cal.toJdn(1001, 13, 6)).toThrow(INVALID_DAY);
   });
+
+  it("should determine whether an Ethiopic year is a leap year", () => {
+    // Ethiopic leap years are `year % 4 === 3` (matching Coptic; epochs differ by 276 = 0 mod 4).
+    const leapYears = [3, 7, 1991, 1995, 1999, 2003, 2007, 2011, 2015, 2019, 2023, 2027];
+    const nonLeapYears = [
+      0, 1, 2, 1990, 1992, 1993, 1994, 1996, 1997, 1998, 2000, 2001, 2002, 2004, 2005, 2006, 2008,
+      2009, 2010, 2012, 2013, 2014, 2016, 2017, 2018, 2020, 2021, 2022, 2024, 2025, 2026, 2028,
+      2029, 2030,
+    ];
+
+    for (const year of leapYears) {
+      expect(cal.isLeapYear(year)).toBe(true);
+    }
+
+    for (const year of nonLeapYears) {
+      expect(cal.isLeapYear(year)).toBe(false);
+    }
+  });
+
+  it("should only accept the sixth epagomenal day in a leap year and reject it otherwise", () => {
+    // Pagumen (month 13) has 6 days in a leap year, 5 in a common year.
+    expect(cal.toJdn(2015, 13, 6)).toBe(2460198.5);
+
+    for (const year of [3, 7, 1991, 1995, 1999, 2003, 2007, 2011, 2015, 2019, 2023, 2027]) {
+      expect(() => cal.toJdn(year, 13, 6)).not.toThrow();
+    }
+
+    for (const year of [
+      0, 1, 2, 1990, 1992, 1993, 1994, 1996, 1997, 1998, 2000, 2001, 2002, 2004, 2005, 2006, 2008,
+      2009, 2010, 2012, 2013, 2014, 2016, 2017, 2018, 2020, 2021, 2022, 2024, 2025, 2026, 2028,
+      2029, 2030,
+    ]) {
+      expect(() => cal.toJdn(year, 13, 6)).toThrow(INVALID_DAY);
+    }
+  });
 });


### PR DESCRIPTION
Closes #675.

Split out of #674 as requested.

`EthiopicCalendar.isLeapYear` used `year % 4 === 0`, but the Ethiopic leap year is `year % 4 === 3` — the rule the sibling `CopticCalendar` already uses. The epochs differ by 276 (0 mod 4), so every Ethiopic year shares leap status with its Coptic twin; the two predicates must agree.

`validate()` bounds the 13th month (Pagumen: 6 days in a leap year, 5 otherwise) with `isLeapYear`, so the wrong rule corrupted `toJdn`:

```
toJdn(2015, 13, 6)  // valid leap day (2023-09-11) -> threw "Invalid day"
toJdn(2016, 13, 6)  // invalid (5-day Pagumen) -> silently returned the JDN of 2017-01-01
```

`fromJdn` never calls `isLeapYear`, so round-trips looked fine and the gap went unnoticed.

Tests use precomputed leap/non-leap arrays (`year === 3 mod 4` matches the existing Ethiopic fixtures), not the leap rule recomputed under test. The Pagumen leap-day boundary is covered explicitly.

`pnpm test` is green; `lint`, `format:check`, and `build:check` are clean.