### PR TITLE
Derive Islamic leap year from each calendar's own conversion (closes #676)

### DIFF
--- a/src/calendar/IslamicObservationalCalendar.ts
+++ b/src/calendar/IslamicObservationalCalendar.ts
@@ -26,9 +26,9 @@ export class IslamicObservationalCalendar {
     return phasisOnOrBefore(midMonth, islamic.LOCATION_CAIRO) + day - 1;
   }
 
-  // Is a given year in the Islamic Observational calendar a leap year?
+  // Is a given year in the observational Islamic calendar a leap year (a 355-day year)?
   public static isLeapYear(year: number): boolean {
-    return (year * 11 + 14) % 30 < 11;
+    return this.toJdn(year + 1, 1, 1) - this.toJdn(year, 1, 1) > 354;
   }
 
   private static validate(_year: number, month: number, day: number): void {

--- a/src/calendar/IslamicUmmAlQuraCalendar.ts
+++ b/src/calendar/IslamicUmmAlQuraCalendar.ts
@@ -41,9 +41,9 @@ export class IslamicUmmAlQuraCalendar {
     return J0000 + this.saudiNewMonthOnOrBefore(midmonth) + day - 1;
   }
 
-  // Is a given year in the Islamic Umm al-Qura calendar a leap year?
+  // Is a given year in the Umm al-Qura calendar a leap year (a 355-day year)?
   public static isLeapYear(year: number): boolean {
-    return (year * 11 + 14) % 30 < 11;
+    return this.toJdn(year + 1, 1, 1) - this.toJdn(year, 1, 1) > 354;
   }
 
   private static validate(_year: number, month: number, day: number): void {

--- a/test/calendar/Islamic.observational.test.ts
+++ b/test/calendar/Islamic.observational.test.ts
@@ -67,4 +67,25 @@ describe("islamic Observational calendar spec", () => {
     expect(() => cal.toJdn(220, 7, -5)).toThrow(INVALID_DAY);
     expect(() => cal.toJdn(220, 1, 31)).toThrow(INVALID_DAY);
   });
+
+  it("should determine whether an observational Islamic year is a leap year", () => {
+    // An observational Islamic leap year runs 355 days; the tabular-Islamic
+    // `(year * 11 + 14) % 30 < 11` rule disagrees with the calendar's own month
+    // lengths, so the flag is derived from the conversion.
+    const leapYears = [
+      1400, 1404, 1406, 1409, 1412, 1413, 1418, 1419, 1421, 1426, 1427, 1431, 1433, 1435, 1440,
+    ];
+    const nonLeapYears = [
+      1401, 1402, 1403, 1405, 1407, 1408, 1410, 1411, 1414, 1415, 1416, 1417, 1420, 1422, 1423,
+      1424, 1425, 1428, 1429, 1430, 1432, 1434, 1436, 1437, 1438, 1439,
+    ];
+
+    for (const year of leapYears) {
+      expect(cal.isLeapYear(year)).toBe(true);
+    }
+
+    for (const year of nonLeapYears) {
+      expect(cal.isLeapYear(year)).toBe(false);
+    }
+  });
 });

--- a/test/calendar/Islamic.umm.al-qura.test.ts
+++ b/test/calendar/Islamic.umm.al-qura.test.ts
@@ -75,8 +75,31 @@ describe("islamic Umm al-Qura calendar spec", () => {
       jdn: 2435072.5,
       month: 3,
       year: 1374,
-      yearLeap: true,
+      yearLeap: false,
     };
     expect(expected).toEqual(actual);
+  });
+
+  it("should determine whether an Umm al-Qura year is a leap year", () => {
+    // A Umm al-Qura leap year runs 355 days (a 355-day year is leap); the
+    // tabular-Islamic `(year * 11 + 14) % 30 < 11` rule disagrees with the
+    // calendar's own month lengths, so the flag is derived from the conversion.
+    const leapYears = [
+      1404, 1405, 1409, 1411, 1413, 1417, 1419, 1420, 1425, 1426, 1428, 1433, 1435, 1439, 1441,
+      1443, 1447, 1448, 1452, 1454, 1456, 1460,
+    ];
+    const nonLeapYears = [
+      1400, 1401, 1402, 1403, 1406, 1407, 1408, 1410, 1412, 1414, 1415, 1416, 1418, 1421, 1422,
+      1423, 1424, 1427, 1429, 1430, 1431, 1432, 1434, 1436, 1437, 1438, 1440, 1442, 1444, 1445,
+      1446, 1449, 1450, 1451, 1453, 1455, 1457, 1458, 1459,
+    ];
+
+    for (const year of leapYears) {
+      expect(cal.isLeapYear(year)).toBe(true);
+    }
+
+    for (const year of nonLeapYears) {
+      expect(cal.isLeapYear(year)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Closes #676.

Split out of #674 as requested.

`IslamicObservationalCalendar.isLeapYear` and `IslamicUmmAlQuraCalendar.isLeapYear` both copied the tabular-Islamic formula `(year * 11 + 14) % 30 < 11`, but these calendars take their month lengths from crescent visibility / data, not from that arithmetic. The formula disagrees with the year length their own `toJdn` produces — 26 of 61 years for Umm al-Qura (1400-1460) and 18 of 41 for Observational (1400-1440).

Derive the flag from the conversion (`year % day-count > 354`, i.e. a 355-day year is leap), the way `PersianAstronomicalCalendar`, `BahaiAstroCalendar` and `IcelandicCalendar` already do. `toJdn(year, 1, 1) - toJdn(year-1, 1, 1)` is computed twice per call but only on the public leap query, not on the conversion path.

The Umm al-Qura `fromJdn` fixture had baked in the wrong `yearLeap` for year 1374 (a 354-day year, previously asserted true); corrected to false.

Tests use precomputed leap/non-leap arrays taken from each calendar's own `toJdn` over a fixed year range, not the tabular rule recomputed under test.

`pnpm test` is green; `lint`, `format:check`, and `build:check` are clean.