### PR TITLE
Derive Samaritan leap year from the calendar's own conversion (closes #678)

### DIFF
--- a/src/calendar/SamaritanCalendar.ts
+++ b/src/calendar/SamaritanCalendar.ts
@@ -32,8 +32,33 @@ export class SamaritanCalendar {
   }
 
   // Is a given Samaritan year a leap year?
+  //
+  // A Samaritan year is leap when it contains an intercalary month (Adar II): 13
+  // months, ~383-385 days, versus 12 months, ~353-355 days for a common year. The
+  // previous `mod(year * 7 + 4, 19) < 7` Metonic-offset rule was copied verbatim from
+  // HebrewCalendar (which uses `+ 1`) but neither offset matches this calendar's own
+  // conversion, because the year start is observational (`newYearOnOrBefore`, an
+  // apparent-new-moon search), not arithmetic. Derive the flag from the calendar's
+  // own year length, the way PersianAstronomicalCalendar / BahaiAstroCalendar /
+  // IcelandicCalendar already do.
   public static isLeapYear(year: number): boolean {
-    return mod(year * 7 + 4, 19) < 7;
+    return this.yearLengthDays(year) > 360;
+  }
+
+  // Year length, in days, from the calendar's own conversion. Computed directly from
+  // `newYearOnOrBefore` (the same path `toJdn` uses) rather than via `toJdn`, so it
+  // does not re-enter `validate` (which consults `isLeapYear` for month bounds).
+  // Mirrors `toJdn`'s new-year argument for month 7 (Tishrei): `year - ceil((7-5)/8)`.
+  private static yearLengthDays(year: number): number {
+    const monthShift = Math.ceil((7 - 5) / 8); // == 1
+    const start = this.newYearOnOrBefore(
+      Math.floor(samaritan.EPOCH_RD + 50 + 365.25 * (year - monthShift)),
+    );
+    const end = this.newYearOnOrBefore(
+      Math.floor(samaritan.EPOCH_RD + 50 + 365.25 * (year + 1 - monthShift)),
+    );
+
+    return end - start;
   }
 
   private static noon(rataDie: number): number {

--- a/test/calendar/Samaritan.test.ts
+++ b/test/calendar/Samaritan.test.ts
@@ -62,12 +62,35 @@ describe("samaritan calendar spec", () => {
   });
 
   it("should determine whether a Samaritan year is leap year", () => {
-    for (const year of [5700, 5703, 5705, 5708, 5711, 5713, 5716, 5719, 5722, 5724, 5727, 5730]) {
-      expect(cal.isLeapYear(year)).toBeTruthy();
+    // The previous `mod(year * 7 + 4, 19) < 7` rule disagreed with the calendar's
+    // own year length; the years below are pinned to the year length the calendar's
+    // own conversion yields (a 383-385-day year is leap, a 353-355-day year is common).
+    const leapYears = [5696, 5699, 5702, 5704, 5707, 5710, 5713, 5715, 5718, 5721, 5723, 5726];
+    const nonLeapYears = [
+      5695, 5697, 5698, 5700, 5701, 5703, 5705, 5706, 5708, 5709, 5711, 5712, 5714, 5716, 5717,
+      5719, 5720, 5722, 5724, 5725, 5727, 5728, 5730, 5731, 5733, 5735,
+    ];
+
+    for (const year of leapYears) {
+      expect(cal.isLeapYear(year)).toBe(true);
     }
 
-    for (const year of [5701, 5702, 5704, 5706, 5707, 5709, 5710, 5712, 5714, 5715, 5717, 5718]) {
-      expect(cal.isLeapYear(year)).toBeFalsy();
+    for (const year of nonLeapYears) {
+      expect(cal.isLeapYear(year)).toBe(false);
+    }
+  });
+
+  it("should only accept month 13 in a leap year and reject it otherwise", () => {
+    // `validate()` bounds the 13th month to a leap year.
+    for (const year of [5696, 5699, 5702, 5704, 5707, 5710, 5713, 5715, 5718, 5721, 5723, 5726]) {
+      expect(() => cal.toJdn(year, 13, 1)).not.toThrow();
+    }
+
+    for (const year of [
+      5695, 5697, 5698, 5700, 5701, 5703, 5705, 5706, 5708, 5709, 5711, 5712, 5714, 5716, 5717,
+      5719, 5720, 5722, 5724, 5725, 5727, 5728, 5730, 5731, 5733, 5735,
+    ]) {
+      expect(() => cal.toJdn(year, 13, 1)).toThrow(INVALID_MONTH);
     }
   });
 


### PR DESCRIPTION
Closes #678.

`SamaritanCalendar.isLeapYear` used `mod(year * 7 + 4, 19) < 7`, a Metonic offset copied verbatim from `HebrewCalendar` (which uses `+1`). Neither offset matches this calendar's own year length: a 13-month year is ~383-385 days, a 12-month year ~353-355, and the year start is observational (`newYearOnOrBefore`, an apparent-new-moon search), not arithmetic — so no fixed Metonic offset can agree with the year length the calendar's own `toJdn` produces (44 of 71 mismatched for `+4`, 52 of 71 for `+1`, across 5690-5760).

Derive the flag from the calendar's own year length — the same approach `PersianAstronomicalCalendar`, `BahaiAstroCalendar` and `IcelandicCalendar` already use: a year is leap when its own conversion yields more than 360 days (i.e. 13 months). Computed directly from `newYearOnOrBefore`, mirroring `toJdn`'s new-year argument for month 7 (Tishrei: `year - ceil((7-5)/8)`), not via `toJdn`, to avoid re-entering `validate()` (which consults `isLeapYear` via `hebrewYearMonths` and `hebrewMonthDays`).

The pre-existing leap-year test arrays were pinned to the `(year*7+4)%30` rule, which disagreed with the calendar's own conversion; corrected to the year lengths the conversion yields, with a `toJdn(year, 13, 1)` boundary test exercising the `validate()`-month-13 path that `heLeapYear` drives.

`pnpm test` is green; `lint`, `format:check`, and `build:check` are clean.