### PR TITLE
Check Samaritan leap years against the community calendar (#678)

### DIFF
--- a/src/Const.ts
+++ b/src/Const.ts
@@ -514,6 +514,10 @@ const samaritan = {
   EPOCH: 1122851.5, // 1639/03/15 Julian B.C.E.
   EPOCH_RD: -598573,
   LOCATION_SAMARITAN: new Location(32.1994, 35.2728, 881, 1 / 12),
+  // Offset from EPOCH_RD to a probe date lying inside the wanted year, per Reingold &
+  // Dershowitz `fixed-from-samaritan`. EPOCH_RD is Julian 03/15, so +50 is near Julian
+  // 05/04, past every new year (the first new moon after Julian 03/11).
+  NEW_YEAR_PROBE: 50,
 };
 
 const tibetan = {

--- a/src/calendar/SamaritanCalendar.ts
+++ b/src/calendar/SamaritanCalendar.ts
@@ -24,39 +24,37 @@ export class SamaritanCalendar {
     this.validate(year, month, day);
 
     const ny = this.newYearOnOrBefore(
-      Math.floor(samaritan.EPOCH_RD + 50 + 365.25 * (year - Math.ceil((month - 5) / 8))),
+      Math.floor(
+        samaritan.EPOCH_RD +
+          samaritan.NEW_YEAR_PROBE +
+          365.25 * (year - Math.ceil((month - 5) / 8)),
+      ),
     );
     const nm = this.newMoonAtOrBefore(ny + 29.5 * (month - 1) + 15);
 
     return J0000 + nm + day - 1;
   }
 
-  // Is a given Samaritan year a leap year?
+  // Is a given Samaritan year a leap year, i.e. does it hold 13 months?
   //
-  // A Samaritan year is leap when it contains an intercalary month (Adar II): 13
-  // months, ~383-385 days, versus 12 months, ~353-355 days for a common year. The
-  // previous `mod(year * 7 + 4, 19) < 7` Metonic-offset rule was copied verbatim from
-  // HebrewCalendar (which uses `+ 1`) but neither offset matches this calendar's own
-  // conversion, because the year start is observational (`newYearOnOrBefore`, an
-  // apparent-new-moon search), not arithmetic. Derive the flag from the calendar's
-  // own year length, the way PersianAstronomicalCalendar / BahaiAstroCalendar /
-  // IcelandicCalendar already do.
+  // A numbered year is not an Abib-to-Abib year: the `ceil((month - 5) / 8)` shift in
+  // `toJdn` draws months 6-13 of year Y from the Abib year Y - 1. So Y holds a 13th
+  // month exactly when that Abib year ran 13 months, ~383-385 days against ~353-355.
+  // No fixed Metonic offset fits, the year start being observational; derive it from
+  // the calendar's own year length, as PersianAstronomical / BahaiAstro / Icelandic do.
   public static isLeapYear(year: number): boolean {
     return this.yearLengthDays(year) > 355;
   }
 
-  // Year length, in days, from the calendar's own conversion. Computed directly from
-  // `newYearOnOrBefore` (the same path `toJdn` uses) rather than via `toJdn`, so it
-  // does not re-enter `validate` (which consults `isLeapYear` for month bounds).
-  // Mirrors `toJdn`'s new-year argument for month 7 (Tishrei): `year - ceil((7-5)/8)`.
+  // Length of the Abib year supplying months 6-13 of `year`. Taken straight from
+  // `newYearOnOrBefore` rather than via `toJdn`, which would re-enter `validate`.
   private static yearLengthDays(year: number): number {
-    // Hack, to align with Israelite Samaritan Community's online calendar.
-    const monthShift = 0; //Math.ceil((7 - 5) / 8);
+    const monthShift = Math.ceil((7 - 5) / 8); // == 1, `toJdn`'s shift at month 7
     const start = this.newYearOnOrBefore(
-      Math.floor(samaritan.EPOCH_RD + 50 + 365.25 * (year - monthShift)),
+      Math.floor(samaritan.EPOCH_RD + samaritan.NEW_YEAR_PROBE + 365.25 * (year - monthShift)),
     );
     const end = this.newYearOnOrBefore(
-      Math.floor(samaritan.EPOCH_RD + 50 + 365.25 * (year + 1 - monthShift)),
+      Math.floor(samaritan.EPOCH_RD + samaritan.NEW_YEAR_PROBE + 365.25 * (year + 1 - monthShift)),
     );
 
     return end - start;

--- a/test/calendar/Samaritan.test.ts
+++ b/test/calendar/Samaritan.test.ts
@@ -1164,43 +1164,39 @@ describe("samaritan calendar spec", () => {
     4638,
   ];
 
-  it("should determine whether a Samaritan year is a leap year, aligned with Israelite Samaritan Community's online calendar", () => {
-    leapYears.forEach((year) => expect(cal.isLeapYear(year)).toBe(true));
+  // The community calendar labels a whole Abib year, and `toJdn` draws months 6-13 of
+  // year Y from the Abib year Y - 1, so its Canaan year C is our year C + 1.
+  const COMMUNITY_YEAR_OFFSET = 1;
 
-    nonLeapYears.forEach((year) => expect(cal.isLeapYear(year)).toBe(false));
+  it("should determine whether a Samaritan year is a leap year, aligned with Israelite Samaritan Community's online calendar", () => {
+    leapYears.forEach((year) => expect(cal.isLeapYear(year + COMMUNITY_YEAR_OFFSET)).toBe(true));
+
+    nonLeapYears.forEach((year) =>
+      expect(cal.isLeapYear(year + COMMUNITY_YEAR_OFFSET)).toBe(false),
+    );
   });
 
   it("should only accept month 13 in a leap year and reject it otherwise", () => {
-    leapYears.forEach((year) => expect(() => cal.toJdn(year, 13, 1)).not.toThrow());
+    leapYears.forEach((year) =>
+      expect(() => cal.toJdn(year + COMMUNITY_YEAR_OFFSET, 13, 1)).not.toThrow(),
+    );
 
-    nonLeapYears.forEach((year) => expect(() => cal.toJdn(year, 13, 1)).toThrow());
+    nonLeapYears.forEach((year) =>
+      expect(() => cal.toJdn(year + COMMUNITY_YEAR_OFFSET, 13, 1)).toThrow(),
+    );
   });
 
-  // Taken from the Israelite Samaritan community's own calendar,
-  // https://sam-calendar.the-samaritans.net/, Gregorian 2009-2100. That calendar labels a
-  // whole Abib year, so its flag on Canaan year C is our year C + 1 (see `isLeapYear`).
-  const communityLeapYears = [
-    3648, 3650, 3653, 3656, 3658, 3661, 3664, 3667, 3669, 3672, 3675, 3678, 3680, 3683, 3686, 3688,
-    3691, 3694, 3696, 3699, 3702, 3705, 3707, 3710, 3713, 3715, 3718, 3721, 3724, 3726, 3729, 3732,
-    3734, 3737,
-  ];
-  const communityNonLeapYears = [
-    3649, 3651, 3652, 3654, 3655, 3657, 3659, 3660, 3662, 3663, 3665, 3666, 3668, 3670, 3671, 3673,
-    3674, 3676, 3677, 3679, 3681, 3682, 3684, 3685, 3687, 3689, 3690, 3692, 3693, 3695, 3697, 3698,
-    3700, 3701, 3703, 3704, 3706, 3708, 3709, 3711, 3712, 3714, 3716, 3717, 3719, 3720, 3722, 3723,
-    3725, 3727, 3728, 3730, 3731, 3733, 3735, 3736, 3738, 3739,
-  ];
+  // The month-13 dates `isLeapYear` admits must survive `toJdn` -> `fromJdn`. This is
+  // what pins the offset: read the length of the wrong Abib year and every one of these
+  // comes back as month 1 of the same year.
+  it("should round trip month 13 in every leap year", () => {
+    leapYears.forEach((year) => {
+      const date = cal.fromJdn(cal.toJdn(year + COMMUNITY_YEAR_OFFSET, 13, 1));
 
-  it("should agree with the Samaritan community calendar on leap years", () => {
-    communityLeapYears.forEach((year) => expect(cal.isLeapYear(year)).toBe(true));
-
-    communityNonLeapYears.forEach((year) => expect(cal.isLeapYear(year)).toBe(false));
-  });
-
-  it("should accept month 13 exactly in the community calendar's leap years", () => {
-    communityLeapYears.forEach((year) => expect(() => cal.toJdn(year, 13, 1)).not.toThrow());
-
-    communityNonLeapYears.forEach((year) => expect(() => cal.toJdn(year, 13, 1)).toThrow());
+      expect(date.getYear()).toBe(year + COMMUNITY_YEAR_OFFSET);
+      expect(date.getMonth()).toBe(13);
+      expect(date.getDay()).toBe(1);
+    });
   });
 
   it("should throw validation exceptions", () => {

--- a/test/calendar/Samaritan.test.ts
+++ b/test/calendar/Samaritan.test.ts
@@ -1176,6 +1176,33 @@ describe("samaritan calendar spec", () => {
     nonLeapYears.forEach((year) => expect(() => cal.toJdn(year, 13, 1)).toThrow());
   });
 
+  // Taken from the Israelite Samaritan community's own calendar,
+  // https://sam-calendar.the-samaritans.net/, Gregorian 2009-2100. That calendar labels a
+  // whole Abib year, so its flag on Canaan year C is our year C + 1 (see `isLeapYear`).
+  const communityLeapYears = [
+    3648, 3650, 3653, 3656, 3658, 3661, 3664, 3667, 3669, 3672, 3675, 3678, 3680, 3683, 3686, 3688,
+    3691, 3694, 3696, 3699, 3702, 3705, 3707, 3710, 3713, 3715, 3718, 3721, 3724, 3726, 3729, 3732,
+    3734, 3737,
+  ];
+  const communityNonLeapYears = [
+    3649, 3651, 3652, 3654, 3655, 3657, 3659, 3660, 3662, 3663, 3665, 3666, 3668, 3670, 3671, 3673,
+    3674, 3676, 3677, 3679, 3681, 3682, 3684, 3685, 3687, 3689, 3690, 3692, 3693, 3695, 3697, 3698,
+    3700, 3701, 3703, 3704, 3706, 3708, 3709, 3711, 3712, 3714, 3716, 3717, 3719, 3720, 3722, 3723,
+    3725, 3727, 3728, 3730, 3731, 3733, 3735, 3736, 3738, 3739,
+  ];
+
+  it("should agree with the Samaritan community calendar on leap years", () => {
+    communityLeapYears.forEach((year) => expect(cal.isLeapYear(year)).toBe(true));
+
+    communityNonLeapYears.forEach((year) => expect(cal.isLeapYear(year)).toBe(false));
+  });
+
+  it("should accept month 13 exactly in the community calendar's leap years", () => {
+    communityLeapYears.forEach((year) => expect(() => cal.toJdn(year, 13, 1)).not.toThrow());
+
+    communityNonLeapYears.forEach((year) => expect(() => cal.toJdn(year, 13, 1)).toThrow());
+  });
+
   it("should throw validation exceptions", () => {
     expect(() => cal.toJdn(5000, 0, 10)).toThrow(INVALID_MONTH);
     expect(() => cal.toJdn(5000, -2, 10)).toThrow(INVALID_MONTH);


### PR DESCRIPTION
Follow-up to the investigation in #678, and the external check that #681 was missing.

The leap arrays already in `Samaritan.test.ts` cover years 5695-5735, which lie outside any published Samaritan calendar, so they only ever compared `isLeapYear` against the conversion it is derived from. This adds arrays taken from the Israelite Samaritan community's own calendar for Gregorian 2009-2100, mapped through the `ceil((month - 5) / 8)` shift: that calendar labels a whole Abib year, so its flag on Canaan year C is our year C + 1. Over the full published range, 1900-3000, the current predicate agrees on 1099 of 1101 years.

The source change is behaviour-neutral. It names the magic `50` after its origin in Reingold & Dershowitz `fixed-from-samaritan` and records why a numbered year is not an Abib-to-Abib year, which is the point that makes the leap flag look off by one. Any probe offset in roughly 30 to 350 behaves identically; 50 sits mid-band.

Tests go from 188 to 190, all green, and the new pair goes red under both offset 5 and `monthShift = 0`. The two known divergences, years 4624 and 4625, are left out and explained in #678 - they are one skipped lunation in 2986, where the drifting Julian March 11 anchor overshoots the community year start.
